### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+name: Publish package
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+    - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+permissions: {}
+
+jobs:
+  create-release:
+    name: Create new release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish
+        uses: toitlang/pkg-publish@v1.5.0

--- a/examples/calibration.toit
+++ b/examples/calibration.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
-import gpio
 import i2c
 import lsm303d show *
 import system.storage
@@ -23,8 +22,8 @@ The calibration settings are stored in the flash with the key
 main:
   bucket := storage.Bucket.open --flash "toitware/toit-lsm303d"
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device Lsm303d.I2C_ADDRESS
   lsm303d := Lsm303d device

--- a/examples/heading.toit
+++ b/examples/heading.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
-import gpio
 import i2c
 import math
 import lsm303d show *
@@ -14,8 +13,8 @@ Example program demonstrating the 'heading' function of the LSM303D.
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device Lsm303d.I2C_ADDRESS
   bucket := storage.Bucket.open --flash "toitware/toit-lsm303d"

--- a/examples/main.toit
+++ b/examples/main.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a Zero-Clause BSD license that can
 // be found in the EXAMPLES_LICENSE file.
 
-import gpio
 import i2c
 import lsm303d show *
 
@@ -13,8 +12,8 @@ Example program for reading acceleration and magnetometer values
 
 main:
   bus := i2c.Bus
-    --sda=gpio.Pin 21
-    --scl=gpio.Pin 22
+    --sda=21
+    --scl=22
 
   device := bus.device Lsm303d.I2C_ADDRESS
   lsm303d := Lsm303d device

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
 name: lsm303d
 description: Driver for the LSM303D accelerometer and magnetometer.
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196

--- a/package.yaml
+++ b/package.yaml
@@ -1,2 +1,4 @@
 name: lsm303d
 description: Driver for the LSM303D accelerometer and magnetometer.
+environment:
+  sdk: ^2.0.0-alpha.194.1


### PR DESCRIPTION
Updates the package for the SDK 2.0.0-alpha.196 peripheral API by passing integer GPIO numbers to peripheral constructors and raising the SDK constraint. It also brings the package publishing workflow up to date where needed.