### PR TITLE
Fix compass heading and sensor data handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 packages/
+.packages/
 .jaguar

--- a/examples/calibration.toit
+++ b/examples/calibration.toit
@@ -51,8 +51,9 @@ main:
     if z > max_z: max_z = z
     counter++
     // Update the store every 32 values.
-    if counter & 0x1F == 0:
-      calibration := [(max_x + min_x) / 2, (max_y + min_y) / 2, (max_z + min_z) / 2]
+    if counter & 0x1F == 0 and
+        min_x < max_x and min_y < max_y and min_z < max_z:
+      calibration := [min_x, min_y, min_z, max_x, max_y, max_z]
       if calibration != old_calibration:
         old_calibration = calibration
         bucket["lsm303d-mag-calibration"] = calibration

--- a/src/accelerometer.toit
+++ b/src/accelerometer.toit
@@ -101,8 +101,9 @@ class Accelerometer:
     // We always enable all three axes.
     axes_bits := 0b111
 
+    ctrl1 := rate_bits | axes_bits
     // Prevent an update while output bytes are being read.
-    ctrl1 := rate_bits | BDU_BIT_ | axes_bits
+    ctrl1 |= BDU_BIT_
 
     // 8.18. CTRL2.
     // Anti-alias filter bandwidth set to default (0).

--- a/src/accelerometer.toit
+++ b/src/accelerometer.toit
@@ -4,6 +4,7 @@
 
 import serial.device as serial
 import serial.registers as serial
+import io
 import math
 
 /**
@@ -44,6 +45,9 @@ class Accelerometer:
   static OUT_Y_H_A_ ::= 0x2B
   static OUT_Z_L_A_ ::= 0x2C
   static OUT_Z_H_A_ ::= 0x2D
+
+  static BDU_BIT_ ::= 1 << 3
+  static AUTO_INCREMENT_BIT_ ::= 1 << 7
 
   /**
   Standard acceleration due to gravity.
@@ -97,7 +101,8 @@ class Accelerometer:
     // We always enable all three axes.
     axes_bits := 0b111
 
-    ctrl1 := rate_bits | axes_bits
+    // Prevent an update while output bytes are being read.
+    ctrl1 := rate_bits | BDU_BIT_ | axes_bits
 
     // 8.18. CTRL2.
     // Anti-alias filter bandwidth set to default (0).
@@ -122,18 +127,18 @@ class Accelerometer:
   disable:
     // Fundamentally we only care for the rate-bits: as long as they
     // are 0, the device is disabled.
-    // It's safe to change the other bits as well.
-    reg_.write_u8 CTRL1_ 0x00
+    // Keep BDU enabled because it also applies to magnetic data.
+    reg_.write_u8 CTRL1_ (BDU_BIT_ | 0b111)
 
   /**
   Reads the x, y and z axis.
   The returned values are in in m/s².
   */
   read -> math.Point3f:
-    AUTO_INCREMENT_BIT ::= 0b1000_0000
-    x := reg_.read_i16_le (OUT_X_L_A_ | AUTO_INCREMENT_BIT)
-    y := reg_.read_i16_le (OUT_Y_L_A_ | AUTO_INCREMENT_BIT)
-    z := reg_.read_i16_le (OUT_Z_L_A_ | AUTO_INCREMENT_BIT)
+    raw := read_raw_
+    x := raw[0]
+    y := raw[1]
+    z := raw[2]
 
     // Section 2.1, table3:
     // The linear acceleration sensitivity depends on the range:
@@ -157,12 +162,7 @@ class Accelerometer:
   read --raw/bool -> List:
     if not raw: throw "INVALID_ARGUMENT"
 
-    AUTO_INCREMENT_BIT ::= 0b1000_0000
-    x := reg_.read_i16_le (OUT_X_L_A_ | AUTO_INCREMENT_BIT)
-    y := reg_.read_i16_le (OUT_Y_L_A_ | AUTO_INCREMENT_BIT)
-    z := reg_.read_i16_le (OUT_Z_L_A_ | AUTO_INCREMENT_BIT)
-
-    return [x, y, z]
+    return read_raw_
 
   /**
   Reads the current range setting of the sensor.
@@ -172,3 +172,10 @@ class Accelerometer:
     reg4 := reg_.read_u8 CTRL2_
     return (reg4 >> 3) & 0b111
 
+  read_raw_ -> List:
+    bytes := reg_.read_bytes (OUT_X_L_A_ | AUTO_INCREMENT_BIT_) 6
+    return [
+      io.LITTLE_ENDIAN.int16 bytes 0,
+      io.LITTLE_ENDIAN.int16 bytes 2,
+      io.LITTLE_ENDIAN.int16 bytes 4,
+    ]

--- a/src/lsm303d.toit
+++ b/src/lsm303d.toit
@@ -53,7 +53,7 @@ class Lsm303d:
 vector_cross_ v1/math.Point3f v2/math.Point3f -> math.Point3f:
   return math.Point3f
       v1.y * v2.z - v1.z * v2.y
-      v1.x * v2.z - v1.z * v2.x
+      v1.z * v2.x - v1.x * v2.z
       v1.x * v2.y - v1.y * v2.x
 
 vector_dot_ v1/math.Point3f v2/math.Point3f -> float:

--- a/src/magnetometer.toit
+++ b/src/magnetometer.toit
@@ -123,6 +123,7 @@ class Magnetometer:
   */
   read_temperature -> float:
     // Section 4.2.
+    // Unlike the LSM303DLHC, the LSM303D stores temperature right-justified.
     // The value is a right-justified, 12-bit two's complement integer.
     // 8 steps per degree. This means that there are 3 fractional bits.
     // If we just wanted to return an integer temperature value we could

--- a/src/magnetometer.toit
+++ b/src/magnetometer.toit
@@ -4,6 +4,7 @@
 
 import serial.device as serial
 import serial.registers as serial
+import io
 import math
 
 /**
@@ -23,9 +24,13 @@ class Magnetometer:
   static OUT_Y_H_M_ ::= 0x0B
   static OUT_Z_L_M_ ::= 0x0C
   static OUT_Z_H_M_ ::= 0x0D
+  static CTRL1_ ::= 0x20
   static CTRL5_ ::= 0x24
   static CTRL6_ ::= 0x25
   static CTRL7_ ::= 0x26
+
+  static BDU_BIT_ ::= 1 << 3
+  static AUTO_INCREMENT_BIT_ ::= 1 << 7
 
   // Section 8.21, Table 47.
   static RATE_3_125HZ ::= 0
@@ -46,23 +51,27 @@ class Magnetometer:
   static GAUSS_TO_MICROTESLA_ ::= 100.0
 
   reg_ /serial.Registers
-  calibration_ /List
+  calibration_offsets_ /List := [0, 0, 0]
+  calibration_scales_ /List := [1.0, 1.0, 1.0]
   range_ /int := 0
 
 
   /**
   Constructs a new Magnetometer.
 
-  The $calibration should be a 3-element list, containing the
-    the calibration value of each axis. The calibration value is
-    simply the average value of min and max raw values (see $(read --raw)).
-    Typically, the user moves the sensor in a figure 8, while the
-    calibration program is collecting all seen values.
+  The $calibration may be a 6-element list containing the minimum values for
+    X, Y, and Z followed by the maximum values for X, Y, and Z. These values
+    correct both the offset and relative scale of each axis. Typically, the
+    user moves the sensor in a figure 8 while the calibration program collects
+    all seen values.
+
+  For backwards compatibility, a 3-element list is interpreted as an offset
+    for each axis.
   */
   constructor dev/serial.Device --calibration=[0, 0, 0]:
     reg_ = dev.registers
 
-    calibration_ = calibration
+    set_calibration_ calibration
 
     id := reg_.read_u8 WHO_AM_I_
     // Section 8.6, Table 19.
@@ -90,6 +99,10 @@ class Magnetometer:
     range_ = range
     reg_.write_u8 CTRL6_ ctrl6
 
+    // BDU is in CTRL1 and applies to both acceleration and magnetic data.
+    ctrl1 := reg_.read_u8 CTRL1_
+    reg_.write_u8 CTRL1_ (ctrl1 | BDU_BIT_)
+
     // Section 8.23. Table 54.
     // High-pass filter. Default 0.
     // Filtered acceleration data selection. Default 0.
@@ -109,20 +122,15 @@ class Magnetometer:
   Returns the result in Celsius.
   */
   read_temperature -> float:
-    // 7.2.9, Table 86.
-    // 12 bit signed integer shifted by 4. In other words: a 16 bit integer with
-    //   the least significant 4 bits not used.
+    // Section 4.2.
+    // The value is a right-justified, 12-bit two's complement integer.
     // 8 steps per degree. This means that there are 3 fractional bits.
     // If we just wanted to return an integer temperature value we could
-    //   return `value >> 7`.
-    // TODO(florian): check that the least 4 significant bits are equal to 0.
-    //   Shouldn't matter too much if they aren't.
-    low := reg_.read_u8 TEMP_OUT_L_
-    high := reg_.read_u8 TEMP_OUT_H_
-    // value := reg_.read_i16_le TEMP_OUT_L_
-    value := (high << 8) | low
-    // TODO(florian): see whether the division by 8 is correct.
-    // Also: we seem to get very few digits.
+    //   return `value >> 3`.
+    bytes := reg_.read_bytes (TEMP_OUT_L_ | AUTO_INCREMENT_BIT_) 2
+    value := io.LITTLE_ENDIAN.uint16 bytes 0
+    value &= 0x0fff
+    if value & 0x0800 != 0: value -= 0x1000
     return value * (1.0 / 8.0) + 25.0  // Let the compiler constant-fold the division.
 
   /**
@@ -133,10 +141,10 @@ class Magnetometer:
     sensor to measure the magnetic field.
   */
   read -> math.Point3f:
-    AUTO_INCREMENT_BIT ::= 0b1000_0000
-    x := reg_.read_i16_le (OUT_X_L_M_ | AUTO_INCREMENT_BIT)
-    z := reg_.read_i16_le (OUT_Z_L_M_ | AUTO_INCREMENT_BIT)
-    y := reg_.read_i16_le (OUT_Y_L_M_ | AUTO_INCREMENT_BIT)
+    raw := read_raw_
+    x := raw[0]
+    y := raw[1]
+    z := raw[2]
 
     gain := ?
     if range_ == RANGE_2G: gain = 0.080
@@ -148,9 +156,9 @@ class Magnetometer:
       // things easier.
       gain = 0.479
 
-    x_calibrated := x - calibration_[0]
-    y_calibrated := y - calibration_[1]
-    z_calibrated := z - calibration_[2]
+    x_calibrated := (x - calibration_offsets_[0]) * calibration_scales_[0]
+    y_calibrated := (y - calibration_offsets_[1]) * calibration_scales_[1]
+    z_calibrated := (z - calibration_offsets_[2]) * calibration_scales_[2]
 
     x_converted := x_calibrated * gain * (GAUSS_TO_MICROTESLA_ / 1000.0)
     y_converted := y_calibrated * gain * (GAUSS_TO_MICROTESLA_ / 1000.0)
@@ -180,9 +188,42 @@ class Magnetometer:
   read --raw/bool -> List:
     if not raw: throw "INVALID_ARGUMENT"
 
-    AUTO_INCREMENT_BIT ::= 0b1000_0000
-    x := reg_.read_i16_le (OUT_X_H_M_ | AUTO_INCREMENT_BIT)
-    z := reg_.read_i16_le (OUT_Z_H_M_ | AUTO_INCREMENT_BIT)
-    y := reg_.read_i16_le (OUT_Y_H_M_ | AUTO_INCREMENT_BIT)
+    return read_raw_
 
-    return [x, y, z]
+  read_raw_ -> List:
+    bytes := reg_.read_bytes (OUT_X_L_M_ | AUTO_INCREMENT_BIT_) 6
+    return [
+      io.LITTLE_ENDIAN.int16 bytes 0,
+      io.LITTLE_ENDIAN.int16 bytes 2,
+      io.LITTLE_ENDIAN.int16 bytes 4,
+    ]
+
+  set_calibration_ calibration/List -> none:
+    if calibration.size == 3:
+      calibration_offsets_ = calibration
+      calibration_scales_ = [1.0, 1.0, 1.0]
+      return
+
+    if calibration.size != 6: throw "INVALID_CALIBRATION"
+    calibration.do:
+      if it is not num: throw "INVALID_CALIBRATION"
+
+    ranges := [
+      calibration[3] - calibration[0],
+      calibration[4] - calibration[1],
+      calibration[5] - calibration[2],
+    ]
+    ranges.do:
+      if it <= 0: throw "INVALID_CALIBRATION"
+
+    average_range := (ranges[0] + ranges[1] + ranges[2]) / 3.0
+    calibration_offsets_ = [
+      (calibration[3] + calibration[0]) / 2.0,
+      (calibration[4] + calibration[1]) / 2.0,
+      (calibration[5] + calibration[2]) / 2.0,
+    ]
+    calibration_scales_ = [
+      average_range / ranges[0],
+      average_range / ranges[1],
+      average_range / ranges[2],
+    ]

--- a/tests/driver_test.toit
+++ b/tests/driver_test.toit
@@ -1,0 +1,151 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file.
+
+import expect show *
+import io
+import math
+import serial.device show Device
+import serial.registers show Registers
+
+import lsm303d show Lsm303d
+import lsm303d.accelerometer show Accelerometer
+import lsm303d.magnetometer show Magnetometer
+
+WHO-AM-I ::= 0x0f
+CTRL1 ::= 0x20
+OUT-X-L-M ::= 0x08
+OUT-Y-L-M ::= 0x0a
+OUT-Z-L-M ::= 0x0c
+OUT-X-L-A ::= 0x28
+OUT-Y-L-A ::= 0x2a
+OUT-Z-L-A ::= 0x2c
+TEMP-OUT-L ::= 0x05
+
+main:
+  test-cross-product
+  test-raw-magnetometer-read
+  test-bdu
+  test-temperature
+  test-calibration
+
+test-cross-product:
+  registers := test-registers
+  registers.set-i16 OUT-X-L-A 0
+  registers.set-i16 OUT-Y-L-A 0
+  registers.set-i16 OUT-Z-L-A 16_384
+  registers.set-i16 OUT-X-L-M 1_000
+  registers.set-i16 OUT-Y-L-M 1_000
+  registers.set-i16 OUT-Z-L-M 0
+
+  sensor := Lsm303d (FakeDevice registers)
+  sensor.enable
+  heading := sensor.heading (math.Point3f 1 0 0)
+  expect-close 45.0 heading
+
+test-raw-magnetometer-read:
+  registers := test-registers
+  magnetometer := Magnetometer (FakeDevice registers)
+  registers.set-i16 OUT-X-L-M 0x1234
+  registers.set-i16 OUT-Y-L-M -1_234
+  registers.set-i16 OUT-Z-L-M 0x2345
+
+  expect-list-equals [0x1234, -1_234, 0x2345]
+    magnetometer.read --raw
+
+test-bdu:
+  registers := test-registers
+  accelerometer := Accelerometer (FakeDevice registers)
+  accelerometer.enable
+  expect-equals 0x6f registers[CTRL1]
+
+  // Magnetometer-only use also enables BDU while preserving CTRL1.
+  registers[CTRL1] = 0x67
+  magnetometer := Magnetometer (FakeDevice registers)
+  magnetometer.enable
+  expect-equals 0x6f registers[CTRL1]
+
+  accelerometer.disable
+  expect-equals 0x0f registers[CTRL1]
+
+test-temperature:
+  registers := test-registers
+  magnetometer := Magnetometer (FakeDevice registers)
+
+  // +8 LSB is one degree above the nominal 25 °C reference.
+  registers[TEMP-OUT-L] = 0x08
+  registers[TEMP-OUT-L + 1] = 0x00
+  expect-close 26.0 magnetometer.read-temperature
+
+  // 0xff8 is -8 in right-justified 12-bit two's complement.
+  registers[TEMP-OUT-L] = 0xf8
+  registers[TEMP-OUT-L + 1] = 0x0f
+  expect-close 24.0 magnetometer.read-temperature
+
+test-calibration:
+  registers := test-registers
+  calibration := [-1_000, -500, -2_000, 1_000, 500, 2_000]
+  magnetometer := Magnetometer (FakeDevice registers) --calibration=calibration
+
+  // These values are at the same relative position on all three axes.
+  registers.set-i16 OUT-X-L-M 500
+  registers.set-i16 OUT-Y-L-M 250
+  registers.set-i16 OUT-Z-L-M 1_000
+  field := magnetometer.read
+  expect-close field.x field.y
+  expect-close field.x field.z
+
+  // Existing three-offset calibrations remain supported.
+  old-calibration := Magnetometer (FakeDevice registers) --calibration=[100, 200, 300]
+  registers.set-i16 OUT-X-L-M 200
+  registers.set-i16 OUT-Y-L-M 300
+  registers.set-i16 OUT-Z-L-M 400
+  old-field := old-calibration.read
+  expect-close old-field.x old-field.y
+  expect-close old-field.x old-field.z
+
+expect-close expected/num actual/num:
+  expect (expected - actual).abs < 0.000_001
+
+test-registers -> FakeRegisters:
+  result := FakeRegisters
+  result[WHO-AM-I] = 0x49
+  return result
+
+class FakeDevice implements Device:
+  registers_/Registers
+
+  constructor .registers_:
+
+  registers -> Registers:
+    return registers_
+
+  read amount/int -> ByteArray:
+    throw "UNIMPLEMENTED"
+
+  write bytes/ByteArray -> none:
+    throw "UNIMPLEMENTED"
+
+class FakeRegisters extends Registers:
+  bytes_/ByteArray := ByteArray 0x80
+
+  read-bytes register/int count/int -> ByteArray:
+    address := register & 0x7f
+    result := ByteArray count
+    count.repeat:
+      result[it] = bytes_[address + it]
+    return result
+
+  write-bytes register/int data/ByteArray -> none:
+    address := register & 0x7f
+    data.size.repeat:
+      bytes_[address + it] = data[it]
+
+  operator [] index/int -> int:
+    return bytes_[index]
+
+  operator []= index/int value/int -> none:
+    bytes_[index] = value
+
+  set-i16 register/int value/int -> none:
+    io.LITTLE-ENDIAN.put-int16 bytes_ register value

--- a/tests/package.lock
+++ b/tests/package.lock
@@ -1,0 +1,6 @@
+sdk: ^2.0.0-alpha.196
+prefixes:
+  lsm303d: toit-lsm303d
+packages:
+  toit-lsm303d:
+    path: ..

--- a/tests/package.yaml
+++ b/tests/package.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  lsm303d:
+    path: ..


### PR DESCRIPTION
## Summary

- correct the Y component of the heading cross product
- read accelerometer and magnetometer XYZ values as coherent six-byte bursts starting at the low-byte register
- enable block data update for both combined and magnetometer-only use
- decode temperature as right-justified signed 12-bit two complement data
- retain magnetometer min/max calibration and compensate relative axis scale while accepting existing three-offset calibrations
- add host-side regression coverage for heading, raw reads, BDU, temperature, and calibration

Angle wrapping is intentionally unchanged.

## Testing

- toit analyze -Werror src/lsm303d.toit src/magnetometer.toit src/accelerometer.toit
- toit analyze -Werror --project-root examples examples/heading.toit examples/calibration.toit examples/main.toit
- toit analyze -Werror --project-root tests tests/driver_test.toit
- toit run --project-root tests tests/driver_test.toit